### PR TITLE
not using USB serial driver, code not supported under Windows

### DIFF
--- a/Makefile.win32
+++ b/Makefile.win32
@@ -28,7 +28,7 @@ PKG_CFLAGS = `$(CCPRE)pkg-config --cflags $(PKG_LIST) | sed "s:-I/$(MPLATFORM):-
 PKG_LIBS = `$(CCPRE)pkg-config --libs $(PKG_LIST) | sed "s:-L/$(MPLATFORM):-L$(DEPS):g"`
 
 CFLAGS = -Wall -pedantic -Wno-overlength-strings -Wno-long-long -DCURL_STATICLIB -D__USE_MINGW_ANSI_STDIO -I . -I $(DEPS)/include -I ./win32/ $(PKG_CFLAGS)
-LIBS = $(PKG_LIBS) -L$(DEPS)/bin -L./win32/ -lwinscard -lreadline -lncurses
+LIBS = $(PKG_LIBS) -L./win32/ -L$(DEPS)/bin -lwinscard -lreadline -lncurses
 
 build:		cardpeek.exe
 
@@ -49,7 +49,7 @@ win32/resource.o:	win32/resource.rc
 
 #TODO: shouldn't be needed. To be confirmed. (It seems at least that it's not needed to compile)
 #win32/libwinscard.a:	win32/winscard.def win32/winscard.h
-#			$(CCPRE)dlltool -k -d win32/winscard.def -l win32/libwinscard.a win32/winscard.dll
+#			$(CCPRE)dlltool -k -d win32/winscard.def -l win32/libwinscard.a /c/Windows/System32/winscard.dll
 
 clean:			
 			rm -f $(OBJECTS) cardpeek.exe win32/libwinscard.a dot_cardpeek.tar.gz *~ cardpeek_resources.c

--- a/smartcard.c
+++ b/smartcard.c
@@ -93,7 +93,9 @@ const char **cardmanager_reader_name_list(cardmanager_t* cm)
 #include "ui.h"
 #include "drivers/null_driver.c"
 #include "drivers/pcsc_driver.c"
+#ifndef _WIN32
 #include "drivers/usbserial_driver.c"
+#endif
 #include "drivers/replay_driver.c"
 
 cardreader_t* cardreader_new(const char *card_reader_name)
@@ -111,11 +113,13 @@ cardreader_t* cardreader_new(const char *card_reader_name)
     reader->name=strdup(card_reader_name);
     if (pcsc_initialize(reader)==0) return NULL;
   }
+#ifndef _WIN32
   else if (strncmp(card_reader_name,"usbserial://",12)==0)
   {
     reader->name=strdup(card_reader_name);
     if (usbserial_initialize(reader)==0) return NULL;
   }
+#endif
   else if (strncmp(card_reader_name,"replay://",9)==0)
   {
     reader->name=strdup(card_reader_name);


### PR DESCRIPTION
The compilation does not work under Windows. This is fixing it. I will cut the other larger pull request into smaller ones. Windows and Linux are working now. 
The notes that the produced binaries are not working can also be removed, I will also fix the readmes taking this into account.